### PR TITLE
Remove hypercorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,16 +129,16 @@ ENTRYPOINT ["/bin/bash", "-c", "set -e && \
 WORKER_CLASS=${WORKER_CLASS:-uvicorn.workers.UvicornWorker} && \
 PORT=${PORT:-5000} && \
 IP=${IP:-0.0.0.0} && \
-echo '==================================================' && \
-echo '   Starting EMHASS Energy Management System' && \
-echo '==================================================' && \
-echo '   Configuration:' && \
-echo '   Server Type: async (Quart with gunicorn + uvicorn workers)' && \
-echo \"   Worker Class: $WORKER_CLASS\" && \
-echo \"   Bind Address: $IP:$PORT\" && \
-echo '   Python Path: $(which python3 2>/dev/null || echo N/A)' && \
-echo '   UV Version: $(uv --version 2>/dev/null || echo N/A)' && \
-echo '==================================================' && \
+echo "=================================================="\
+echo "   Starting EMHASS Energy Management System"\
+echo "=================================================="\
+echo "   Configuration:"\
+echo "   Server Type: $EMHASS_SERVER_TYPE"\
+echo "   Worker Class: $WORKER_CLASS"\
+echo "   Bind Address: $IP:$PORT"\
+echo "   Python Path: $(which python3 2>/dev/null || echo 'N/A')"\
+echo "   UV Version: $(uv --version 2>/dev/null || echo 'N/A')"\
+echo "=================================================="\
 echo 'Using asynchronous Quart server with gunicorn + uvicorn workers' && \
 echo \"Starting gunicorn with $WORKER_CLASS workers...\" && \
 exec uv run --frozen gunicorn emhass.web_server_async:app -c gunicorn.conf.py -k \"$WORKER_CLASS\""]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,17 +30,11 @@ case "$EMHASS_SERVER_TYPE" in
         echo "Starting gunicorn with $WORKER_CLASS workers..."
         exec uv run --frozen gunicorn emhass.web_server_async:app -c gunicorn.conf.py -k "$WORKER_CLASS"
         ;;
-    hypercorn)
-        echo "Using Hypercorn ASGI server (legacy mode)"
-        echo "Starting hypercorn server..."
-        exec uv run --frozen hypercorn emhass.web_server_async:app --bind "$IP:$PORT" --workers 1 --access-logfile - --error-logfile -
-        ;;
     *)
         echo "  ERROR: Unknown server type '$EMHASS_SERVER_TYPE'"
         echo "  Valid options:"
         echo "   - sync: Flask with gunicorn WSGI workers"
         echo "   - async: Quart with gunicorn + uvicorn ASGI workers (recommended)"
-        echo "   - hypercorn: Quart with hypercorn ASGI server (legacy)"
         echo ""
         echo "  Example: docker run -e EMHASS_SERVER_TYPE=async your-image"
         exit 1

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -24,10 +24,8 @@ graceful_timeout = 60
 keepalive = 2
 
 # Logging
-accesslog = "-"
 errorlog = "-"
 loglevel = os.getenv("LOG_LEVEL", "warning")
-# access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
 
 # Security
 limit_request_line = 4094

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -26,8 +26,8 @@ keepalive = 2
 # Logging
 accesslog = "-"
 errorlog = "-"
-loglevel = os.getenv("LOG_LEVEL", "info")
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
+loglevel = os.getenv("LOG_LEVEL", "warning")
+# access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
 
 # Security
 limit_request_line = 4094

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -5,10 +5,7 @@ bind = f"{os.getenv('IP', '0.0.0.0')}:{os.getenv('PORT', '5000')}"
 
 # Worker configuration
 workers = int(os.getenv("WEB_CONCURRENCY", 1))
-threads = int(os.getenv("PYTHON_MAX_THREADS", 8))
-
-# Worker class for async support
-worker_class = os.getenv("WORKER_CLASS", "uvicorn.workers.UvicornWorker")
+# Note: threads is not used with async workers (uvicorn), only for sync workers
 
 # Worker connections (only for async workers)
 worker_connections = int(os.getenv("WORKER_CONNECTIONS", 1000))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "gunicorn>=23.0.0",
     "quart",
     "aiofiles",
-    "hypercorn",
     "jinja2",
     "asyncio",
     "aiohttp",

--- a/src/emhass/web_server_async.py
+++ b/src/emhass/web_server_async.py
@@ -6,7 +6,6 @@ import logging
 import os
 import pickle
 import re
-import signal
 import threading
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -84,7 +83,9 @@ async def before_serving():
         await initialize()
         app.logger.info("Full initialization completed")
     except Exception as e:
-        app.logger.warning(f"Full initialization failed (this is normal in test environments): {e}")
+        app.logger.warning(
+            f"Full initialization failed (this is normal in test environments): {e}"
+        )
         app.logger.info("Continuing without WebSocket connection...")
         # The initialize() function already sets up all necessary components except WebSocket
         # So we can continue serving requests even if WebSocket connection fails
@@ -118,10 +119,14 @@ async def checkFileLog(refString: str | None = None) -> bool:
     logArray: list[str] = []
 
     if refString is not None:
-        logArray = await grabLog(refString)  # grab reduced log array (everything after string match)
+        logArray = await grabLog(
+            refString
+        )  # grab reduced log array (everything after string match)
     else:
         if (emhass_conf["data_path"] / "actionLogs.txt").exists():
-            async with aiofiles.open(str(emhass_conf["data_path"] / "actionLogs.txt")) as fp:
+            async with aiofiles.open(
+                str(emhass_conf["data_path"] / "actionLogs.txt")
+            ) as fp:
                 content = await fp.read()
                 logArray = content.splitlines()
         else:
@@ -147,7 +152,9 @@ async def grabLog(refString: str | None = None) -> list[str]:
     isFound = []
     output = []
     if (emhass_conf["data_path"] / "actionLogs.txt").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "actionLogs.txt")) as fp:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "actionLogs.txt")
+        ) as fp:
             content = await fp.read()
             logArray = content.splitlines()
         # Find all string matches, log key (line Number) in isFound
@@ -168,7 +175,9 @@ async def clearFileLog():
 
     """
     if (emhass_conf["data_path"] / "actionLogs.txt").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "actionLogs.txt"), "w") as fp:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "actionLogs.txt"), "w"
+        ) as fp:
             await fp.write("")
 
 
@@ -183,11 +192,15 @@ async def index():
 
     # Load cached dict (if exists), to present generated plot tables
     if (emhass_conf["data_path"] / "injection_dict.pkl").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "rb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "rb"
+        ) as fid:
             content = await fid.read()
             injection_dict = pickle.loads(content)
     else:
-        app.logger.info("The data container dictionary is empty... Please launch an optimization task")
+        app.logger.info(
+            "The data container dictionary is empty... Please launch an optimization task"
+        )
         injection_dict = {}
 
     template = templates.get_template("index.html")
@@ -204,7 +217,9 @@ async def configuration():
 
     # get params
     if (emhass_conf["data_path"] / "params.pkl").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "params.pkl"), "rb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "params.pkl"), "rb"
+        ) as fid:
             content = await fid.read()
             emhass_conf["config_path"], params = pickle.loads(content)
 
@@ -221,7 +236,9 @@ async def template_action():
     app.logger.info(" >> Sending rendered template data")
 
     if (emhass_conf["data_path"] / "injection_dict.pkl").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "rb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "rb"
+        ) as fid:
             content = await fid.read()
             injection_dict = pickle.loads(content)
     else:
@@ -269,7 +286,9 @@ async def config_get():
     """
     app.logger.debug("Obtaining default parameters")
     # Build config, passing only default file
-    config = await build_config(emhass_conf, app.logger, str(emhass_conf["defaults_path"]))
+    config = await build_config(
+        emhass_conf, app.logger, str(emhass_conf["defaults_path"])
+    )
     if type(config) is bool and not config:
         return await make_response(["failed to retrieve default config file"], 500)
     # Format parameters in config with params
@@ -297,7 +316,9 @@ async def json_convert():
     if yaml_config is None:
         return await make_response(["failed to Parse YAML from data"], 400)
     # Test YAML is legacy config format (from config_emhass.yaml)
-    test_legacy_config = await build_legacy_config_params(emhass_conf, yaml_config, app.logger)
+    test_legacy_config = await build_legacy_config_params(
+        emhass_conf, yaml_config, app.logger
+    )
     if test_legacy_config:
         yaml_config = test_legacy_config
     # Format YAML to params (format params. check if params match legacy option.json format)
@@ -321,12 +342,19 @@ async def parameter_set():
     """
     config = {}
     if not emhass_conf["defaults_path"]:
-        return await make_response(["Unable to Obtain defaults_path from emhass_conf"], 500)
+        return await make_response(
+            ["Unable to Obtain defaults_path from emhass_conf"], 500
+        )
     if not emhass_conf["config_path"]:
-        return await make_response(["Unable to Obtain config_path from emhass_conf"], 500)
+        return await make_response(
+            ["Unable to Obtain config_path from emhass_conf"], 500
+        )
 
     # Load defaults as a reference point (for sorting) and a base to override
-    if os.path.exists(emhass_conf["defaults_path"]) and Path(emhass_conf["defaults_path"]).is_file():
+    if (
+        os.path.exists(emhass_conf["defaults_path"])
+        and Path(emhass_conf["defaults_path"]).is_file()
+    ):
         async with aiofiles.open(str(emhass_conf["defaults_path"])) as data:
             content = await data.read()
             config = orjson.loads(content)
@@ -360,7 +388,9 @@ async def parameter_set():
 
     # Save params with updated config
     if os.path.exists(emhass_conf["data_path"]):
-        async with aiofiles.open(str(emhass_conf["data_path"] / "params.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "params.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(
                 (
                     emhass_conf["config_path"],
@@ -369,7 +399,9 @@ async def parameter_set():
             )
             await fid.write(content)
     else:
-        return await make_response(["Unable to save params file, missing data_path"], 500)
+        return await make_response(
+            ["Unable to save params file, missing data_path"], 500
+        )
 
     app.logger.info("Saved parameters from webserver")
     return await make_response({}, 201)
@@ -392,7 +424,9 @@ async def action_call(action_name: str):
     ActionStr = " >> Obtaining params: "
     app.logger.info(ActionStr)
     if (emhass_conf["data_path"] / "params.pkl").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "params.pkl"), "rb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "params.pkl"), "rb"
+        ) as fid:
             content = await fid.read()
             emhass_conf["config_path"], params = pickle.loads(content)
             # Set local costfun variable
@@ -426,7 +460,9 @@ async def action_call(action_name: str):
     if action_name == "export-influxdb-to-csv":
         ActionStr = " >> Exporting InfluxDB data to CSV..."
         app.logger.info(ActionStr)
-        success = await export_influxdb_to_csv(None, app.logger, emhass_conf, params, runtimeparams)
+        success = await export_influxdb_to_csv(
+            None, app.logger, emhass_conf, params, runtimeparams
+        )
         if success:
             msg = "EMHASS >> Action export-influxdb-to-csv executed successfully... \n"
             if not await checkFileLog(ActionStr):
@@ -435,16 +471,22 @@ async def action_call(action_name: str):
 
     ActionStr = " >> Setting input data dict"
     app.logger.info(ActionStr)
-    input_data_dict = await set_input_data_dict(emhass_conf, costfun, params, runtimeparams, action_name, app.logger)
+    input_data_dict = await set_input_data_dict(
+        emhass_conf, costfun, params, runtimeparams, action_name, app.logger
+    )
     if not input_data_dict:
         return await make_response(await grabLog(ActionStr), 400)
 
     # If continual_publish is True, start thread with loop function
-    if len(continual_publish_thread) == 0 and input_data_dict["retrieve_hass_conf"].get("continual_publish", False):
+    if len(continual_publish_thread) == 0 and input_data_dict["retrieve_hass_conf"].get(
+        "continual_publish", False
+    ):
         # Start Thread
         continualLoop = threading.Thread(
             name="continual_publish",
-            target=lambda: asyncio.run(continual_publish(input_data_dict, entity_path, app.logger)),
+            target=lambda: asyncio.run(
+                continual_publish(input_data_dict, entity_path, app.logger)
+            ),
         )
         continualLoop.start()
         continual_publish_thread.append(continualLoop)
@@ -466,7 +508,9 @@ async def action_call(action_name: str):
         app.logger.info(ActionStr)
         opt_res = await perfect_forecast_optim(input_data_dict, app.logger)
         injection_dict = get_injection_dict(opt_res)
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(injection_dict)
             await fid.write(content)
         msg = "EMHASS >> Action perfect-optim executed... \n"
@@ -479,7 +523,9 @@ async def action_call(action_name: str):
         app.logger.info(ActionStr)
         opt_res = await dayahead_forecast_optim(input_data_dict, app.logger)
         injection_dict = get_injection_dict(opt_res)
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(injection_dict)
             await fid.write(content)
         msg = "EMHASS >> Action dayahead-optim executed... \n"
@@ -492,7 +538,9 @@ async def action_call(action_name: str):
         app.logger.info(ActionStr)
         opt_res = await naive_mpc_optim(input_data_dict, app.logger)
         injection_dict = get_injection_dict(opt_res)
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(injection_dict)
             await fid.write(content)
         msg = "EMHASS >> Action naive-mpc-optim executed... \n"
@@ -505,7 +553,9 @@ async def action_call(action_name: str):
         app.logger.info(ActionStr)
         df_fit_pred, _, mlf = await forecast_model_fit(input_data_dict, app.logger)
         injection_dict = get_injection_dict_forecast_model_fit(df_fit_pred, mlf)
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(injection_dict)
             await fid.write(content)
         msg = "EMHASS >> Action forecast-model-fit executed... \n"
@@ -521,10 +571,16 @@ async def action_call(action_name: str):
             return await make_response(await grabLog(ActionStr), 400)
         table1 = df_pred.reset_index().to_html(classes="mystyle", index=False)
         injection_dict = {}
-        injection_dict["title"] = "<h2>Custom machine learning forecast model predict</h2>"
-        injection_dict["subsubtitle0"] = "<h4>Performed a prediction using a pre-trained model</h4>"
+        injection_dict["title"] = (
+            "<h2>Custom machine learning forecast model predict</h2>"
+        )
+        injection_dict["subsubtitle0"] = (
+            "<h4>Performed a prediction using a pre-trained model</h4>"
+        )
         injection_dict["table1"] = table1
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(injection_dict)
             await fid.write(content)
         msg = "EMHASS >> Action forecast-model-predict executed... \n"
@@ -539,7 +595,9 @@ async def action_call(action_name: str):
         if df_pred_optim is None or mlf is None:
             return await make_response(await grabLog(ActionStr), 400)
         injection_dict = get_injection_dict_forecast_model_tune(df_pred_optim, mlf)
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps(injection_dict)
             await fid.write(content)
         msg = "EMHASS >> Action forecast-model-tune executed... \n"
@@ -571,7 +629,7 @@ async def action_call(action_name: str):
         return await make_response(msg, 400)
 
 
-async def initialize():
+async def initialize(args: dict | None = None):
     global emhass_conf, params_secrets, continual_publish_thread, injection_dict, entity_path
 
     config = {}
@@ -582,9 +640,15 @@ async def initialize():
     ROOT_PATH = os.getenv("ROOT_PATH", default=str(Path(__file__).parent))
     CONFIG_PATH = os.getenv("CONFIG_PATH", default="/share/config.json")
     OPTIONS_PATH = os.getenv("OPTIONS_PATH", default="/data/options.json")
-    DEFAULTS_PATH = os.getenv("DEFAULTS_PATH", default=ROOT_PATH + "/data/config_defaults.json")
-    ASSOCIATIONS_PATH = os.getenv("ASSOCIATIONS_PATH", default=ROOT_PATH + "/data/associations.csv")
-    LEGACY_CONFIG_PATH = os.getenv("LEGACY_CONFIG_PATH", default="/app/config_emhass.yaml")
+    DEFAULTS_PATH = os.getenv(
+        "DEFAULTS_PATH", default=ROOT_PATH + "/data/config_defaults.json"
+    )
+    ASSOCIATIONS_PATH = os.getenv(
+        "ASSOCIATIONS_PATH", default=ROOT_PATH + "/data/associations.csv"
+    )
+    LEGACY_CONFIG_PATH = os.getenv(
+        "LEGACY_CONFIG_PATH", default="/app/config_emhass.yaml"
+    )
 
     # Define the paths
     config_path = Path(CONFIG_PATH)
@@ -627,6 +691,13 @@ async def initialize():
     # Argument
     argument = {}
     no_response = False
+    if args is not None:
+        if args.get("url", None):
+            argument["url"] = args["url"]
+        if args.get("key", None):
+            argument["key"] = args["key"]
+        if args.get("no_response", None):
+            no_response = args["no_response"]
 
     # Combine secrets from ENV, Arguments/ARG, Secrets file (secrets_emhass.yaml), options (options.json from addon configuration file) and/or Home Assistant Standalone API (if exist)
     emhass_conf, secrets = await build_secrets(
@@ -653,7 +724,9 @@ async def initialize():
 
     # Initialize this global dict
     if (emhass_conf["data_path"] / "injection_dict.pkl").exists():
-        async with aiofiles.open(str(emhass_conf["data_path"] / "injection_dict.pkl"), "rb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "injection_dict.pkl"), "rb"
+        ) as fid:
             content = await fid.read()
             injection_dict = pickle.loads(content)
     else:
@@ -669,14 +742,18 @@ async def initialize():
 
     # Save params to file for later reference
     if os.path.exists(str(emhass_conf["data_path"])):
-        async with aiofiles.open(str(emhass_conf["data_path"] / "params.pkl"), "wb") as fid:
+        async with aiofiles.open(
+            str(emhass_conf["data_path"] / "params.pkl"), "wb"
+        ) as fid:
             content = pickle.dumps((config_path, params))
             await fid.write(content)
     else:
         raise Exception("missing: " + str(emhass_conf["data_path"]))
 
     # Define loggers
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     log.default_handler.setFormatter(formatter)
     # Action file logger
     fileLogger = logging.FileHandler(str(emhass_conf["data_path"] / "actionLogs.txt"))
@@ -715,8 +792,13 @@ async def initialize():
 
     # Logging
     port = int(os.environ.get("PORT", 5000))
-    app.logger.info("Launching the emhass webserver at: http://" + server_ip + ":" + str(port))
-    app.logger.info("Home Assistant data fetch will be performed using url: " + params_secrets["hass_url"])
+    app.logger.info(
+        "Launching the emhass webserver at: http://" + server_ip + ":" + str(port)
+    )
+    app.logger.info(
+        "Home Assistant data fetch will be performed using url: "
+        + params_secrets["hass_url"]
+    )
     app.logger.info("The data path is: " + str(emhass_conf["data_path"]))
     app.logger.info("The logging is: " + str(logging_level))
     try:
@@ -765,7 +847,7 @@ async def main() -> None:
     args_dict = {k: v for k, v in vars(args).items() if v is not None}
 
     # Initialize the app before starting server
-    await initialize()
+    await initialize(args_dict)
 
     # For direct execution (development/testing), use uvicorn programmatically
     import uvicorn


### PR DESCRIPTION
## Summary by Sourcery

Remove Hypercorn support and standardize on Quart served by gunicorn with uvicorn workers, simplifying server startup and configuration.

New Features:
- Support running the async Quart app directly with uvicorn when executing the module for development or testing.

Enhancements:
- Simplify the async web server entrypoint by inlining Docker startup logic and removing the separate shell script.
- Streamline gunicorn configuration for async workers by removing unused thread settings and reducing log verbosity.

Build:
- Update Dockerfile to drop the external entrypoint script, set default IP/PORT environment variables, and start gunicorn directly via an inline bash entrypoint.

Deployment:
- Remove configuration paths and scripts related to the legacy Hypercorn deployment mode.

Documentation:
- Document the recommended production startup command using gunicorn with uvicorn workers in the async server main function docstring.

Chores:
- Remove Hypercorn from Python dependencies and clean up references to the legacy server type.